### PR TITLE
Mac用手順からJAVA_HOME設定手順を除外

### DIFF
--- a/content/installJavaMac.md
+++ b/content/installJavaMac.md
@@ -12,18 +12,7 @@
 
 ## インストールできたら
 
-下記のコマンドを実行して、`JAVA_HOME` を設定してください。
-```
-export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-```
-
-
-その後 [Terminalを起動](tipsForMac.md#terminalの起動方法) して
-```sh
-> echo $JAVA_HOME
-/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home
-```
-というように `echo` コマンドが動くことと、
+[Terminalを起動](tipsForMac.md#terminalの起動方法) して
 ```sh
 > java -version
 java version "1.8.0_162"


### PR DESCRIPTION
環境変数 'JAVA_HOME' の設定は必須ではないため、Mac向けの手順から除外しました。
Windows向けも 'JAVA_HOME' は必須ではありませんがリンク先の手順に含まれているため、Windows用の手順は変更しないこととします。